### PR TITLE
chore: Updated format date for message

### DIFF
--- a/lib/extensions/chat_message_ext.dart
+++ b/lib/extensions/chat_message_ext.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/widgets.dart';
 
 import 'package:agora_chat_uikit/agora_chat_uikit.dart';
-import 'package:intl/intl.dart';
 
 extension ChatMessageExt on ChatMessage {
   String summary(BuildContext context) {
@@ -41,16 +40,6 @@ extension ChatMessageExt on ChatMessage {
   }
 
   String get createTs {
-    final dateString = TimeTool.timeStrByMs(serverTime);
-    final dateTime = toDate(dateString);
-    return formatDate(dateTime);
-  }
-
-  DateTime toDate(String date) {
-    return DateFormat("yyyy/MM/dd HH:mm").parse(date);
-  }
-
-  String formatDate(DateTime date) {
-    return DateFormat("MM/dd HH:mm").format(date);
+    return TimeTool.timeStrByMs(serverTime);
   }
 }

--- a/lib/tools/time_tool.dart
+++ b/lib/tools/time_tool.dart
@@ -1,8 +1,6 @@
-enum TimeType {
-  today,
-  month,
-  year,
-}
+import 'package:intl/intl.dart';
+
+enum TimeType { today, month, year }
 
 class TimeTool {
   static TimeType _timeType(int ms) {
@@ -29,16 +27,13 @@ class TimeTool {
     String ret = "";
     switch (type) {
       case TimeType.today:
-        ret =
-            "${date.hour.toString().padLeft(2, '0')}:${date.minute.toString().padLeft(2, '0')}";
+        ret = DateFormat('h:mma').format(date);
         break;
       case TimeType.month:
-        ret =
-            "${date.month.toString().padLeft(2, '0')}/${date.day.toString().padLeft(2, '0')} ${date.hour.toString().padLeft(2, '0')}:${date.minute.toString().padLeft(2, '0')}";
+        ret = DateFormat('MM/dd h:mma').format(date);
         break;
       case TimeType.year:
-        ret =
-            "${date.year.toString()}/${date.month.toString().padLeft(2, '0')}/${date.day.toString().padLeft(2, '0')} ${date.hour.toString().padLeft(2, '0')}:${date.minute.toString().padLeft(2, '0')}";
+        ret = DateFormat('yyyy/MM/dd h:mma').format(date);
         break;
     }
     return ret;

--- a/lib/tools/time_tool.dart
+++ b/lib/tools/time_tool.dart
@@ -9,15 +9,10 @@ class TimeTool {
     DateTime now = DateTime.now();
     DateTime dateToCheck = DateTime.fromMillisecondsSinceEpoch(ms);
     if (now.year == dateToCheck.year) {
-      if (now.month == dateToCheck.month) {
-        if (now.day == dateToCheck.day) {
-          return TimeType.today;
-        } else {
-          return TimeType.month;
-        }
-      } else {
-        return TimeType.year;
+      if (now.month == dateToCheck.month && now.day == dateToCheck.day) {
+        return TimeType.today;
       }
+      return TimeType.month;
     } else {
       return TimeType.year;
     }


### PR DESCRIPTION
- Sửa lỗi hiển thị thời gian khi `final dateString = TimeTool.timeStrByMs(serverTime);` có dạng `HH:mm` nên sử dụng `toDate` hoặc `formatDate` bị lỗi

| Issue | Resolved | Issue | Resolved |
|-|-|-|-|
|![simulator_screenshot_02C109D3-F731-4515-A6A9-88C800B2FA63](https://github.com/user-attachments/assets/f0e8c52e-9ec1-48e8-ae08-376597ff14c0)|![Simulator Screenshot - iPhone 16 Plus - 2025-07-07 at 02 18 14](https://github.com/user-attachments/assets/b1c27ad0-4c3c-49e5-b733-487656c3cd17)|![simulator_screenshot_F3849469-10A3-46C2-B0FD-8664D83350AE](https://github.com/user-attachments/assets/c57079c3-3fbd-4b8f-94ab-a611ff4c3a50)|![Simulator Screenshot - iPhone 16 Plus - 2025-07-07 at 02 18 19](https://github.com/user-attachments/assets/960e973d-62cb-40d0-aa51-ed829621e85f)|


